### PR TITLE
man:xcb-requests: Error handling example improved.

### DIFF
--- a/man/xcb-requests.man
+++ b/man/xcb-requests.man
@@ -76,6 +76,7 @@ void my_example(xcb_connection *conn, xcb_window_t window) {
     /* ... of course your event loop would not be in the same function ... */
     while ((event = xcb_wait_for_event(conn)) != NULL) {
         if (event->response_type == 0) {
+            xcb_generic_error_t *error = (xcb_generic_error_t *)event;
             fprintf("Received X11 error %d\\n", error->error_code);
             free(event);
             continue;


### PR DESCRIPTION
In xcb-requests man page error handling example improved to clarify that
xcb_wait_for_event returns a union object that can be interpreted as
error.